### PR TITLE
feat: inspect Diagnostics extension points

### DIFF
--- a/source/demo/FlashOWare.CodeAnalysis.CSharp.Demo/Diagnostics/CSharpDiagnosticAnalyzerDemo.cs
+++ b/source/demo/FlashOWare.CodeAnalysis.CSharp.Demo/Diagnostics/CSharpDiagnosticAnalyzerDemo.cs
@@ -1,0 +1,45 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FlashOWare.CodeAnalysis.Demo.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+[SuppressMessage("MicrosoftCodeAnalysisReleaseTracking", "RS2008:Enable analyzer release tracking", Justification = "Demo")]
+public sealed class CSharpDiagnosticAnalyzerDemo : DiagnosticAnalyzer
+{
+	private static readonly DiagnosticDescriptor s_rule = new(
+		"CSDEMO1001",
+		"Demo Title",
+		"Demo: Message Format: {0}",
+		"Demo-Category",
+		DiagnosticSeverity.Warning,
+		true,
+		"Demo Description.",
+		"https://github.com/FlashOWare/inspector-roslyn",
+		["DemoTag"]
+	);
+
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [s_rule];
+
+	public override void Initialize(AnalysisContext context)
+	{
+		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+		context.EnableConcurrentExecution();
+
+		context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
+	}
+
+	private static void AnalyzeSymbol(SymbolAnalysisContext context)
+	{
+		Debug.Assert(context.Symbol.Kind == SymbolKind.NamedType, $"SymbolKind: {context.Symbol.Kind}");
+		var symbol = (INamedTypeSymbol)context.Symbol;
+
+		string name = symbol.Name;
+		if (name.Equals("InspectorRoslyn", StringComparison.OrdinalIgnoreCase) && !name.Equals("InspectorRoslyn", StringComparison.Ordinal))
+		{
+			var diagnostic = Diagnostic.Create(s_rule, symbol.Locations[0], name);
+
+			context.ReportDiagnostic(diagnostic);
+		}
+	}
+}

--- a/source/demo/FlashOWare.CodeAnalysis.CSharp.Demo/Diagnostics/CSharpDiagnosticSuppressorDemo.cs
+++ b/source/demo/FlashOWare.CodeAnalysis.CSharp.Demo/Diagnostics/CSharpDiagnosticSuppressorDemo.cs
@@ -1,0 +1,42 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FlashOWare.CodeAnalysis.Demo.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class CSharpDiagnosticSuppressorDemo : DiagnosticSuppressor
+{
+	private static readonly SuppressionDescriptor s_descriptor = new("CSSUPPRESS1001", "CSDEMO1001", "Demo Justification.");
+
+	public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => [s_descriptor];
+
+	public override void ReportSuppressions(SuppressionAnalysisContext context)
+	{
+		foreach (Diagnostic diagnostic in context.ReportedDiagnostics)
+		{
+			ReportSuppression(context, diagnostic);
+		}
+	}
+
+	private static void ReportSuppression(SuppressionAnalysisContext context, Diagnostic diagnostic)
+	{
+		Location location = diagnostic.Location;
+
+		Debug.Assert(location != Location.None, nameof(LocationKind.None));
+		Debug.Assert(location.IsInSource, nameof(location.IsInSource));
+
+		SyntaxNode node = location.SourceTree!.GetRoot(context.CancellationToken).FindNode(location.SourceSpan, false, false);
+		SemanticModel semanticModel = context.GetSemanticModel(location.SourceTree);
+
+		ISymbol? symbol = semanticModel.GetDeclaredSymbol(node, context.CancellationToken);
+		Debug.Assert(symbol!.Kind == SymbolKind.NamedType, $"SymbolKind: {symbol.Kind}");
+		var typeSymbol = (INamedTypeSymbol)symbol;
+		Debug.Assert(typeSymbol.Name.Equals("InspectorRoslyn", StringComparison.OrdinalIgnoreCase) && !typeSymbol.Name.Equals("InspectorRoslyn", StringComparison.Ordinal));
+
+		if (typeSymbol.DeclaredAccessibility != Accessibility.Public)
+		{
+			var suppression = Suppression.Create(s_descriptor, diagnostic);
+			context.ReportSuppression(suppression);
+		}
+	}
+}

--- a/source/demo/FlashOWare.CodeAnalysis.CSharp.Demo/Properties/GlobalSuppressions.cs
+++ b/source/demo/FlashOWare.CodeAnalysis.CSharp.Demo/Properties/GlobalSuppressions.cs
@@ -1,1 +1,3 @@
+[assembly: SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "Roslyn Component - Compiler Extension", Scope = "module")]
+
 [assembly: SuppressMessage("Style", "IDE0130:Namespace does not match folder structure", Justification = "Polyfilling", Scope = "namespace", Target = "~N:System.Runtime.CompilerServices")]

--- a/source/demo/FlashOWare.CodeAnalysis.VisualBasic.Demo/Diagnostics/VisualBasicDiagnosticAnalyzerDemo.cs
+++ b/source/demo/FlashOWare.CodeAnalysis.VisualBasic.Demo/Diagnostics/VisualBasicDiagnosticAnalyzerDemo.cs
@@ -1,0 +1,45 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FlashOWare.CodeAnalysis.Demo.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.VisualBasic)]
+[SuppressMessage("MicrosoftCodeAnalysisReleaseTracking", "RS2008:Enable analyzer release tracking", Justification = "Demo")]
+public sealed class VisualBasicDiagnosticAnalyzerDemo : DiagnosticAnalyzer
+{
+	private static readonly DiagnosticDescriptor s_rule = new(
+		"VBDEMO1001",
+		"Demo Title",
+		"Demo: Message Format: {0}",
+		"Demo-Category",
+		DiagnosticSeverity.Warning,
+		true,
+		"Demo Description.",
+		"https://github.com/FlashOWare/inspector-roslyn",
+		["DemoTag"]
+	);
+
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [s_rule];
+
+	public override void Initialize(AnalysisContext context)
+	{
+		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+		context.EnableConcurrentExecution();
+
+		context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
+	}
+
+	private static void AnalyzeSymbol(SymbolAnalysisContext context)
+	{
+		Debug.Assert(context.Symbol.Kind == SymbolKind.NamedType, $"SymbolKind: {context.Symbol.Kind}");
+		var symbol = (INamedTypeSymbol)context.Symbol;
+
+		string name = symbol.Name;
+		if (name.Equals("InspectorRoslyn", StringComparison.OrdinalIgnoreCase) && !name.Equals("InspectorRoslyn", StringComparison.Ordinal))
+		{
+			var diagnostic = Diagnostic.Create(s_rule, symbol.Locations[0], name);
+
+			context.ReportDiagnostic(diagnostic);
+		}
+	}
+}

--- a/source/demo/FlashOWare.CodeAnalysis.VisualBasic.Demo/Diagnostics/VisualBasicDiagnosticSuppressorDemo.cs
+++ b/source/demo/FlashOWare.CodeAnalysis.VisualBasic.Demo/Diagnostics/VisualBasicDiagnosticSuppressorDemo.cs
@@ -1,0 +1,42 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FlashOWare.CodeAnalysis.Demo.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.VisualBasic)]
+public sealed class VisualBasicDiagnosticSuppressorDemo : DiagnosticSuppressor
+{
+	private static readonly SuppressionDescriptor s_descriptor = new("VBSUPPRESS1001", "VBDEMO1001", "Demo Justification.");
+
+	public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => [s_descriptor];
+
+	public override void ReportSuppressions(SuppressionAnalysisContext context)
+	{
+		foreach (Diagnostic diagnostic in context.ReportedDiagnostics)
+		{
+			ReportSuppression(context, diagnostic);
+		}
+	}
+
+	private static void ReportSuppression(SuppressionAnalysisContext context, Diagnostic diagnostic)
+	{
+		Location location = diagnostic.Location;
+
+		Debug.Assert(location != Location.None, nameof(LocationKind.None));
+		Debug.Assert(location.IsInSource, nameof(location.IsInSource));
+
+		SyntaxNode node = location.SourceTree!.GetRoot(context.CancellationToken).FindNode(location.SourceSpan, false, false);
+		SemanticModel semanticModel = context.GetSemanticModel(location.SourceTree);
+
+		ISymbol? symbol = semanticModel.GetDeclaredSymbol(node, context.CancellationToken);
+		Debug.Assert(symbol!.Kind == SymbolKind.NamedType, $"SymbolKind: {symbol.Kind}");
+		var typeSymbol = (INamedTypeSymbol)symbol;
+		Debug.Assert(typeSymbol.Name.Equals("InspectorRoslyn", StringComparison.OrdinalIgnoreCase) && !typeSymbol.Name.Equals("InspectorRoslyn", StringComparison.Ordinal));
+
+		if (typeSymbol.DeclaredAccessibility != Accessibility.Public)
+		{
+			var suppression = Suppression.Create(s_descriptor, diagnostic);
+			context.ReportSuppression(suppression);
+		}
+	}
+}

--- a/source/demo/FlashOWare.CodeAnalysis.VisualBasic.Demo/Properties/GlobalSuppressions.cs
+++ b/source/demo/FlashOWare.CodeAnalysis.VisualBasic.Demo/Properties/GlobalSuppressions.cs
@@ -1,1 +1,3 @@
+[assembly: SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "Roslyn Component - Compiler Extension", Scope = "module")]
+
 [assembly: SuppressMessage("Style", "IDE0130:Namespace does not match folder structure", Justification = "Polyfilling", Scope = "namespace", Target = "~N:System.Runtime.CompilerServices")]

--- a/source/lib/FlashOWare.CodeAnalysis.Inspection.Core/Components/CompilerExtension.cs
+++ b/source/lib/FlashOWare.CodeAnalysis.Inspection.Core/Components/CompilerExtension.cs
@@ -1,51 +1,54 @@
+using FlashOWare.CodeAnalysis.Inspection.Reflection;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace FlashOWare.CodeAnalysis.Inspection.Components;
 
 public abstract class CompilerExtension
 {
-	protected CompilerExtension(string name, string[] languages)
-		: this(name, languages.ToImmutableArray())
+	private protected CompilerExtension(Type type)
 	{
+		Debug.Assert(type.IsClass);
+
+		Class = ClassInfo.Create(type);
 	}
 
-	protected CompilerExtension(string name, ImmutableArray<string> languages)
-	{
-		ClassName = name;
-		Languages = languages;
-	}
-
-	public string ClassName { get; }
-
-	public ImmutableArray<string> Languages { get; }
+	public ClassInfo Class { get; }
 }
 
 public sealed class AnalyzerInfo : CompilerExtension
 {
-	public AnalyzerInfo(string name, ImmutableArray<string> languages, ImmutableArray<DiagnosticDescriptor> supportedDiagnostics)
-		: base(name, languages)
+	internal AnalyzerInfo(Type type, DiagnosticAnalyzerAttribute attribute, ImmutableArray<DiagnosticDescriptor> supportedDiagnostics)
+		: base(type)
 	{
+		Attribute = attribute;
 		SupportedDiagnostics = supportedDiagnostics;
 	}
 
+	public DiagnosticAnalyzerAttribute Attribute { get; }
 	public ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
 }
 
 public sealed class SuppressorInfo : CompilerExtension
 {
-	public SuppressorInfo(string name, ImmutableArray<string> languages, ImmutableArray<SuppressionDescriptor> supportedSuppressions)
-		: base(name, languages)
+	internal SuppressorInfo(Type type, DiagnosticAnalyzerAttribute attribute, ImmutableArray<SuppressionDescriptor> supportedSuppressions)
+		: base(type)
 	{
+		Attribute = attribute;
 		SupportedSuppressions = supportedSuppressions;
 	}
 
+	public DiagnosticAnalyzerAttribute Attribute { get; }
 	public ImmutableArray<SuppressionDescriptor> SupportedSuppressions { get; }
 }
 
 public sealed class GeneratorInfo : CompilerExtension
 {
-	public GeneratorInfo(string name, ImmutableArray<string> languages)
-		: base(name, languages)
+	internal GeneratorInfo(Type type, GeneratorAttribute attribute)
+		: base(type)
 	{
+		Attribute = attribute;
 	}
+
+	public GeneratorAttribute Attribute { get; }
 }

--- a/source/lib/FlashOWare.CodeAnalysis.Inspection.Core/Components/CompilerExtension.cs
+++ b/source/lib/FlashOWare.CodeAnalysis.Inspection.Core/Components/CompilerExtension.cs
@@ -1,14 +1,15 @@
+using Microsoft.CodeAnalysis;
+
 namespace FlashOWare.CodeAnalysis.Inspection.Components;
 
-public sealed class CompilerExtension
+public abstract class CompilerExtension
 {
-	internal CompilerExtension(string name, string[] languages)
+	protected CompilerExtension(string name, string[] languages)
+		: this(name, languages.ToImmutableArray())
 	{
-		ClassName = name;
-		Languages = languages.ToImmutableArray();
 	}
 
-	internal CompilerExtension(string name, ImmutableArray<string> languages)
+	protected CompilerExtension(string name, ImmutableArray<string> languages)
 	{
 		ClassName = name;
 		Languages = languages;
@@ -17,4 +18,34 @@ public sealed class CompilerExtension
 	public string ClassName { get; }
 
 	public ImmutableArray<string> Languages { get; }
+}
+
+public sealed class AnalyzerInfo : CompilerExtension
+{
+	public AnalyzerInfo(string name, ImmutableArray<string> languages, ImmutableArray<DiagnosticDescriptor> supportedDiagnostics)
+		: base(name, languages)
+	{
+		SupportedDiagnostics = supportedDiagnostics;
+	}
+
+	public ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+}
+
+public sealed class SuppressorInfo : CompilerExtension
+{
+	public SuppressorInfo(string name, ImmutableArray<string> languages, ImmutableArray<SuppressionDescriptor> supportedSuppressions)
+		: base(name, languages)
+	{
+		SupportedSuppressions = supportedSuppressions;
+	}
+
+	public ImmutableArray<SuppressionDescriptor> SupportedSuppressions { get; }
+}
+
+public sealed class GeneratorInfo : CompilerExtension
+{
+	public GeneratorInfo(string name, ImmutableArray<string> languages)
+		: base(name, languages)
+	{
+	}
 }

--- a/source/lib/FlashOWare.CodeAnalysis.Inspection.Core/Components/RoslynComponent.cs
+++ b/source/lib/FlashOWare.CodeAnalysis.Inspection.Core/Components/RoslynComponent.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -43,7 +42,7 @@ public static class RoslynComponent
 				{
 					var suppressor = (DiagnosticSuppressor)Activator.CreateInstance(type)!;
 
-					var extension = new SuppressorInfo(type.FullName, ImmutableCollectionsMarshal.AsImmutableArray(attribute.Languages), suppressor.SupportedSuppressions);
+					var extension = new SuppressorInfo(type, attribute, suppressor.SupportedSuppressions);
 
 					extensions.Add(extension);
 					continue;
@@ -56,7 +55,7 @@ public static class RoslynComponent
 				{
 					var analyzer = (DiagnosticAnalyzer)Activator.CreateInstance(type)!;
 
-					var extension = new AnalyzerInfo(type.FullName, ImmutableCollectionsMarshal.AsImmutableArray(attribute.Languages), analyzer.SupportedDiagnostics);
+					var extension = new AnalyzerInfo(type, attribute, analyzer.SupportedDiagnostics);
 
 					extensions.Add(extension);
 					continue;
@@ -70,7 +69,7 @@ public static class RoslynComponent
 					object? generator = Activator.CreateInstance(type);
 					_ = generator;
 
-					var extension = new GeneratorInfo(type.FullName, ImmutableCollectionsMarshal.AsImmutableArray(attribute.Languages));
+					var extension = new GeneratorInfo(type, attribute);
 
 					extensions.Add(extension);
 					continue;

--- a/source/lib/FlashOWare.CodeAnalysis.Inspection.Core/Components/RoslynComponent.cs
+++ b/source/lib/FlashOWare.CodeAnalysis.Inspection.Core/Components/RoslynComponent.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace FlashOWare.CodeAnalysis.Inspection.Components;
 
@@ -21,10 +22,62 @@ public static class RoslynComponent
 
 	private static ImmutableArray<CompilerExtension> Inspect(Assembly component)
 	{
-		return [.. component.GetExportedTypes()
-			.Where(static (Type type) => type.GetCustomAttribute<GeneratorAttribute>() is not null)
-			.Where(static (Type type) => type.FullName is not null)
-			.Select(static (Type type) => new CompilerExtension(type.FullName!, ImmutableCollectionsMarshal.AsImmutableArray(type.GetCustomAttribute<GeneratorAttribute>()!.Languages)))
-		];
+		Type[] types = component.GetExportedTypes();
+		return GetCompilerExtensions(types);
+	}
+
+	private static ImmutableArray<CompilerExtension> GetCompilerExtensions(Type[] types)
+	{
+		ImmutableArray<CompilerExtension>.Builder extensions = ImmutableArray.CreateBuilder<CompilerExtension>();
+
+		foreach (Type type in types)
+		{
+			if (type.FullName is null)
+			{
+				continue;
+			}
+
+			if (type.IsAssignableTo(typeof(DiagnosticSuppressor)))
+			{
+				if (type.GetCustomAttribute<DiagnosticAnalyzerAttribute>() is { } attribute)
+				{
+					var suppressor = (DiagnosticSuppressor)Activator.CreateInstance(type)!;
+
+					var extension = new SuppressorInfo(type.FullName, ImmutableCollectionsMarshal.AsImmutableArray(attribute.Languages), suppressor.SupportedSuppressions);
+
+					extensions.Add(extension);
+					continue;
+				}
+			}
+
+			if (type.IsAssignableTo(typeof(DiagnosticAnalyzer)))
+			{
+				if (type.GetCustomAttribute<DiagnosticAnalyzerAttribute>() is { } attribute)
+				{
+					var analyzer = (DiagnosticAnalyzer)Activator.CreateInstance(type)!;
+
+					var extension = new AnalyzerInfo(type.FullName, ImmutableCollectionsMarshal.AsImmutableArray(attribute.Languages), analyzer.SupportedDiagnostics);
+
+					extensions.Add(extension);
+					continue;
+				}
+			}
+
+			if (type.IsAssignableTo(typeof(ISourceGenerator)) || type.IsAssignableTo(typeof(IIncrementalGenerator)))
+			{
+				if (type.GetCustomAttribute<GeneratorAttribute>() is { } attribute)
+				{
+					object? generator = Activator.CreateInstance(type);
+					_ = generator;
+
+					var extension = new GeneratorInfo(type.FullName, ImmutableCollectionsMarshal.AsImmutableArray(attribute.Languages));
+
+					extensions.Add(extension);
+					continue;
+				}
+			}
+		}
+
+		return extensions.DrainToImmutable();
 	}
 }

--- a/source/lib/FlashOWare.CodeAnalysis.Inspection.Core/Reflection/ClassInfo.cs
+++ b/source/lib/FlashOWare.CodeAnalysis.Inspection.Core/Reflection/ClassInfo.cs
@@ -1,0 +1,20 @@
+namespace FlashOWare.CodeAnalysis.Inspection.Reflection;
+
+public sealed class ClassInfo
+{
+	public static ClassInfo Create(Type type)
+	{
+		return new ClassInfo(type);
+	}
+
+	private readonly Type _type;
+
+	private ClassInfo(Type type)
+	{
+		_type = type;
+	}
+
+	public string Name => _type.Name;
+	public string? Namespace => _type.Namespace;
+	public string? FullName => _type.FullName;
+}

--- a/source/tests/FlashOWare.CodeAnalysis.Inspection.Core.Tests/Assertions/ClassInfoAssertions.cs
+++ b/source/tests/FlashOWare.CodeAnalysis.Inspection.Core.Tests/Assertions/ClassInfoAssertions.cs
@@ -1,0 +1,16 @@
+using FlashOWare.CodeAnalysis.Inspection.Reflection;
+
+namespace FlashOWare.CodeAnalysis.Inspection.Tests.Assertions;
+
+internal static class ClassInfoAssertions
+{
+	extension(Assert)
+	{
+		internal static void AreStructuralEqual(Type expected, ClassInfo actual, string? message = "")
+		{
+			Assert.That(
+				() => StringComparer.Ordinal.Equals(expected.Name, actual.Name) && StringComparer.Ordinal.Equals(expected.Namespace, actual.Namespace) && StringComparer.Ordinal.Equals(expected.FullName, actual.FullName),
+				message);
+		}
+	}
+}

--- a/source/tests/FlashOWare.CodeAnalysis.Inspection.Core.Tests/Assertions/CompilerExtensionAssertions.cs
+++ b/source/tests/FlashOWare.CodeAnalysis.Inspection.Core.Tests/Assertions/CompilerExtensionAssertions.cs
@@ -1,5 +1,4 @@
 using FlashOWare.CodeAnalysis.Inspection.Components;
-using Testing = Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace FlashOWare.CodeAnalysis.Inspection.Tests.Assertions;
 
@@ -7,14 +6,54 @@ internal static class CompilerExtensionAssertions
 {
 	extension(CompilerExtension extension)
 	{
-		internal void Assert(string name, ReadOnlySpan<string> languages)
+		internal void AssertAnalyzer(string name, ReadOnlySpan<string> languages, ReadOnlySpan<string> supportedDiagnostics)
 		{
-			Testing.Assert.AreEqual(name, extension.ClassName, "Name.");
+			var analyzer = Assert.IsInstanceOfType<AnalyzerInfo>(extension);
 
-			Testing.Assert.HasCount(languages.Length, extension.Languages, "Languages.");
+			Assert.AreEqual(name, analyzer.ClassName, "Name.");
+
+			Assert.HasCount(languages.Length, analyzer.Languages, "Languages.");
 			for (int i = 0; i < languages.Length; i++)
 			{
-				Testing.Assert.AreEqual(languages[i], extension.Languages[i], $"At Index {i}.");
+				Assert.AreEqual(languages[i], analyzer.Languages[i], $"At Index {i}.");
+			}
+
+			Assert.HasCount(supportedDiagnostics.Length, analyzer.SupportedDiagnostics, "SupportedDiagnostics.");
+			for (int i = 0; i < supportedDiagnostics.Length; i++)
+			{
+				Assert.AreEqual(supportedDiagnostics[i], analyzer.SupportedDiagnostics[i].Id, $"At Index {i}.");
+			}
+		}
+		
+		internal void AssertSuppressor(string name, ReadOnlySpan<string> languages, ReadOnlySpan<string> supportedSuppressions)
+		{
+			var suppressor = Assert.IsInstanceOfType<SuppressorInfo>(extension);
+
+			Assert.AreEqual(name, suppressor.ClassName, "Name.");
+
+			Assert.HasCount(languages.Length, suppressor.Languages, "Languages.");
+			for (int i = 0; i < languages.Length; i++)
+			{
+				Assert.AreEqual(languages[i], suppressor.Languages[i], $"At Index {i}.");
+			}
+
+			Assert.HasCount(supportedSuppressions.Length, suppressor.SupportedSuppressions, "SupportedSuppressions.");
+			for (int i = 0; i < supportedSuppressions.Length; i++)
+			{
+				Assert.AreEqual(supportedSuppressions[i], suppressor.SupportedSuppressions[i].Id, $"At Index {i}.");
+			}
+		}
+
+		internal void AssertGenerator(string name, ReadOnlySpan<string> languages)
+		{
+			var generator = Assert.IsInstanceOfType<GeneratorInfo>(extension);
+
+			Assert.AreEqual(name, generator.ClassName, "Name.");
+
+			Assert.HasCount(languages.Length, generator.Languages, "Languages.");
+			for (int i = 0; i < languages.Length; i++)
+			{
+				Assert.AreEqual(languages[i], generator.Languages[i], $"At Index {i}.");
 			}
 		}
 	}

--- a/source/tests/FlashOWare.CodeAnalysis.Inspection.Core.Tests/Assertions/CompilerExtensionAssertions.cs
+++ b/source/tests/FlashOWare.CodeAnalysis.Inspection.Core.Tests/Assertions/CompilerExtensionAssertions.cs
@@ -1,60 +1,51 @@
+using System.Collections.ObjectModel;
 using FlashOWare.CodeAnalysis.Inspection.Components;
+using Microsoft.CodeAnalysis;
 
 namespace FlashOWare.CodeAnalysis.Inspection.Tests.Assertions;
 
 internal static class CompilerExtensionAssertions
 {
+	private static readonly Comparer<object?> s_diagnosticComparer = Comparer<object?>.Create(static int (object? x, object? y) =>
+	{
+		var left = Assert.IsInstanceOfType<string>(x);
+		var right = Assert.IsInstanceOfType<DiagnosticDescriptor>(y);
+		return StringComparer.Ordinal.Compare(left, right.Id);
+	});
+
+	private static readonly Comparer<object?> s_suppressionComparer = Comparer<object?>.Create(static int (object? x, object? y) =>
+	{
+		var left = Assert.IsInstanceOfType<string>(x);
+		var right = Assert.IsInstanceOfType<SuppressionDescriptor>(y);
+		return StringComparer.Ordinal.Compare(left, right.Id);
+	});
+
 	extension(CompilerExtension extension)
 	{
-		internal void AssertAnalyzer(string name, ReadOnlySpan<string> languages, ReadOnlySpan<string> supportedDiagnostics)
+		internal void AssertAnalyzer(Type type, ReadOnlyCollection<string> languages, ReadOnlyCollection<string> supportedDiagnostics)
 		{
 			var analyzer = Assert.IsInstanceOfType<AnalyzerInfo>(extension);
 
-			Assert.AreEqual(name, analyzer.ClassName, "Name.");
-
-			Assert.HasCount(languages.Length, analyzer.Languages, "Languages.");
-			for (int i = 0; i < languages.Length; i++)
-			{
-				Assert.AreEqual(languages[i], analyzer.Languages[i], $"At Index {i}.");
-			}
-
-			Assert.HasCount(supportedDiagnostics.Length, analyzer.SupportedDiagnostics, "SupportedDiagnostics.");
-			for (int i = 0; i < supportedDiagnostics.Length; i++)
-			{
-				Assert.AreEqual(supportedDiagnostics[i], analyzer.SupportedDiagnostics[i].Id, $"At Index {i}.");
-			}
+			Assert.AreStructuralEqual(type, analyzer.Class, "Analyzer Class.");
+			CollectionAssert.AreEqual(languages, analyzer.Attribute.Languages, StringComparer.Ordinal, "Analyzer Languages.");
+			CollectionAssert.AreEqual(supportedDiagnostics, analyzer.SupportedDiagnostics, s_diagnosticComparer, "Supported Diagnostics.");
 		}
-		
-		internal void AssertSuppressor(string name, ReadOnlySpan<string> languages, ReadOnlySpan<string> supportedSuppressions)
+
+		internal void AssertSuppressor(Type type, ReadOnlyCollection<string> languages, ReadOnlyCollection<string> supportedSuppressions)
 		{
 			var suppressor = Assert.IsInstanceOfType<SuppressorInfo>(extension);
 
-			Assert.AreEqual(name, suppressor.ClassName, "Name.");
-
-			Assert.HasCount(languages.Length, suppressor.Languages, "Languages.");
-			for (int i = 0; i < languages.Length; i++)
-			{
-				Assert.AreEqual(languages[i], suppressor.Languages[i], $"At Index {i}.");
-			}
-
-			Assert.HasCount(supportedSuppressions.Length, suppressor.SupportedSuppressions, "SupportedSuppressions.");
-			for (int i = 0; i < supportedSuppressions.Length; i++)
-			{
-				Assert.AreEqual(supportedSuppressions[i], suppressor.SupportedSuppressions[i].Id, $"At Index {i}.");
-			}
+			Assert.AreStructuralEqual(type, suppressor.Class, "Suppressor Class.");
+			CollectionAssert.AreEqual(languages, suppressor.Attribute.Languages, StringComparer.Ordinal, "Suppressor Languages.");
+			CollectionAssert.AreEqual(supportedSuppressions, suppressor.SupportedSuppressions, s_suppressionComparer, "Supported Suppressions.");
 		}
 
-		internal void AssertGenerator(string name, ReadOnlySpan<string> languages)
+		internal void AssertGenerator(Type type, ReadOnlyCollection<string> languages)
 		{
 			var generator = Assert.IsInstanceOfType<GeneratorInfo>(extension);
 
-			Assert.AreEqual(name, generator.ClassName, "Name.");
-
-			Assert.HasCount(languages.Length, generator.Languages, "Languages.");
-			for (int i = 0; i < languages.Length; i++)
-			{
-				Assert.AreEqual(languages[i], generator.Languages[i], $"At Index {i}.");
-			}
+			Assert.AreStructuralEqual(type, generator.Class, "Generator Class.");
+			CollectionAssert.AreEqual(languages, generator.Attribute.Languages, StringComparer.Ordinal, "Generator Languages.");
 		}
 	}
 }

--- a/source/tests/FlashOWare.CodeAnalysis.Inspection.Core.Tests/Components/RoslynComponentTests.cs
+++ b/source/tests/FlashOWare.CodeAnalysis.Inspection.Core.Tests/Components/RoslynComponentTests.cs
@@ -40,9 +40,11 @@ public sealed class RoslynComponentTests
 		ImmutableArray<CompilerExtension> extensions = RoslynComponent.Inspect(stream);
 
 		// Assert
-		Assert.HasCount(2, extensions);
-		extensions[0].Assert(RoslynComponentResources.CSharpIncrementalGenerator, [LanguageNames.CSharp]);
-		extensions[1].Assert(RoslynComponentResources.CSharpSourceGenerator, [LanguageNames.CSharp]);
+		Assert.HasCount(4, extensions);
+		extensions[0].AssertGenerator(RoslynComponentResources.CSharpIncrementalGenerator, [LanguageNames.CSharp]);
+		extensions[1].AssertGenerator(RoslynComponentResources.CSharpSourceGenerator, [LanguageNames.CSharp]);
+		extensions[2].AssertAnalyzer(RoslynComponentResources.CSharpDiagnosticAnalyzer, [LanguageNames.CSharp], ["CSDEMO1001"]);
+		extensions[3].AssertSuppressor(RoslynComponentResources.CSharpDiagnosticSuppressor, [LanguageNames.CSharp], ["CSSUPPRESS1001"]);
 	}
 
 	[TestMethod]
@@ -55,9 +57,11 @@ public sealed class RoslynComponentTests
 		ImmutableArray<CompilerExtension> extensions = RoslynComponent.Inspect(stream);
 
 		// Assert
-		Assert.HasCount(2, extensions);
-		extensions[0].Assert(RoslynComponentResources.VisualBasicIncrementalGenerator, [LanguageNames.VisualBasic]);
-		extensions[1].Assert(RoslynComponentResources.VisualBasicSourceGenerator, [LanguageNames.VisualBasic]);
+		Assert.HasCount(4, extensions);
+		extensions[0].AssertGenerator(RoslynComponentResources.VisualBasicIncrementalGenerator, [LanguageNames.VisualBasic]);
+		extensions[1].AssertGenerator(RoslynComponentResources.VisualBasicSourceGenerator, [LanguageNames.VisualBasic]);
+		extensions[2].AssertAnalyzer(RoslynComponentResources.VisualBasicDiagnosticAnalyzer, [LanguageNames.VisualBasic], ["VBDEMO1001"]);
+		extensions[3].AssertSuppressor(RoslynComponentResources.VisualBasicDiagnosticSuppressor, [LanguageNames.VisualBasic], ["VBSUPPRESS1001"]);
 	}
 
 	[TestMethod]

--- a/source/tests/FlashOWare.CodeAnalysis.Inspection.Core.Tests/Components/RoslynComponentTests.cs
+++ b/source/tests/FlashOWare.CodeAnalysis.Inspection.Core.Tests/Components/RoslynComponentTests.cs
@@ -27,7 +27,7 @@ public sealed class RoslynComponentTests
 		ImmutableArray<CompilerExtension> extensions = RoslynComponent.Inspect(stream);
 
 		// Assert
-		Assert.HasCount(0, extensions);
+		Assert.IsEmpty(extensions);
 	}
 
 	[TestMethod]

--- a/source/tests/FlashOWare.CodeAnalysis.Inspection.Core.Tests/Reflection/ClassInfoTests.cs
+++ b/source/tests/FlashOWare.CodeAnalysis.Inspection.Core.Tests/Reflection/ClassInfoTests.cs
@@ -1,0 +1,49 @@
+using FlashOWare.CodeAnalysis.Inspection.Reflection;
+
+namespace FlashOWare.CodeAnalysis.Inspection.Tests.Reflection;
+
+[TestClass]
+public sealed class ClassInfoTests
+{
+	private const string Namespace = "FlashOWare.CodeAnalysis.Inspection.Tests.Reflection";
+	private const string Name = nameof(ClassInfoTests);
+
+	[TestMethod]
+	public void Name_Get_ReturnsTypeName()
+	{
+		// Arrange
+		Type type = typeof(ClassInfoTests);
+
+		// Act
+		var info = ClassInfo.Create(type);
+
+		// Assert
+		Assert.AreEqual($"{Name}", info.Name);
+	}
+
+	[TestMethod]
+	public void Namespace_Get_ReturnsTypeNamespace()
+	{
+		// Arrange
+		Type type = typeof(ClassInfoTests);
+
+		// Act
+		var info = ClassInfo.Create(type);
+
+		// Assert
+		Assert.AreEqual($"{Namespace}", info.Namespace);
+	}
+
+	[TestMethod]
+	public void FullName_Get_ReturnsTypeFullName()
+	{
+		// Arrange
+		Type type = typeof(ClassInfoTests);
+
+		// Act
+		var info = ClassInfo.Create(type);
+
+		// Assert
+		Assert.AreEqual($"{Namespace}.{Name}", info.FullName);
+	}
+}

--- a/source/tests/FlashOWare.CodeAnalysis.Inspection.Core.Tests/Resources/RoslynComponentResources.cs
+++ b/source/tests/FlashOWare.CodeAnalysis.Inspection.Core.Tests/Resources/RoslynComponentResources.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using FlashOWare.CodeAnalysis.Demo.Diagnostics;
 using FlashOWare.CodeAnalysis.Demo.Generators;
 
 namespace FlashOWare.CodeAnalysis.Inspection.Tests.Resources;
@@ -6,11 +7,15 @@ namespace FlashOWare.CodeAnalysis.Inspection.Tests.Resources;
 internal static class RoslynComponentResources
 {
 	internal static Assembly This => typeof(RoslynComponentResources).Assembly;
-	internal static Assembly CSharp => typeof(CSharpSourceGeneratorDemo).Assembly;
-	internal static Assembly VisualBasic => typeof(VisualBasicSourceGeneratorDemo).Assembly;
+	internal static Assembly CSharp => typeof(CSharpDiagnosticAnalyzerDemo).Assembly;
+	internal static Assembly VisualBasic => typeof(VisualBasicDiagnosticAnalyzerDemo).Assembly;
 
+	internal static string CSharpDiagnosticAnalyzer => typeof(CSharpDiagnosticAnalyzerDemo).FullName!;
+	internal static string CSharpDiagnosticSuppressor => typeof(CSharpDiagnosticSuppressorDemo).FullName!;
 	internal static string CSharpSourceGenerator => typeof(CSharpSourceGeneratorDemo).FullName!;
 	internal static string CSharpIncrementalGenerator => typeof(CSharpIncrementalGeneratorDemo).FullName!;
+	internal static string VisualBasicDiagnosticAnalyzer => typeof(VisualBasicDiagnosticAnalyzerDemo).FullName!;
+	internal static string VisualBasicDiagnosticSuppressor => typeof(VisualBasicDiagnosticSuppressorDemo).FullName!;
 	internal static string VisualBasicSourceGenerator => typeof(VisualBasicSourceGeneratorDemo).FullName!;
 	internal static string VisualBasicIncrementalGenerator => typeof(VisualBasicIncrementalGeneratorDemo).FullName!;
 }

--- a/source/tests/FlashOWare.CodeAnalysis.Inspection.Core.Tests/Resources/RoslynComponentResources.cs
+++ b/source/tests/FlashOWare.CodeAnalysis.Inspection.Core.Tests/Resources/RoslynComponentResources.cs
@@ -10,12 +10,12 @@ internal static class RoslynComponentResources
 	internal static Assembly CSharp => typeof(CSharpDiagnosticAnalyzerDemo).Assembly;
 	internal static Assembly VisualBasic => typeof(VisualBasicDiagnosticAnalyzerDemo).Assembly;
 
-	internal static string CSharpDiagnosticAnalyzer => typeof(CSharpDiagnosticAnalyzerDemo).FullName!;
-	internal static string CSharpDiagnosticSuppressor => typeof(CSharpDiagnosticSuppressorDemo).FullName!;
-	internal static string CSharpSourceGenerator => typeof(CSharpSourceGeneratorDemo).FullName!;
-	internal static string CSharpIncrementalGenerator => typeof(CSharpIncrementalGeneratorDemo).FullName!;
-	internal static string VisualBasicDiagnosticAnalyzer => typeof(VisualBasicDiagnosticAnalyzerDemo).FullName!;
-	internal static string VisualBasicDiagnosticSuppressor => typeof(VisualBasicDiagnosticSuppressorDemo).FullName!;
-	internal static string VisualBasicSourceGenerator => typeof(VisualBasicSourceGeneratorDemo).FullName!;
-	internal static string VisualBasicIncrementalGenerator => typeof(VisualBasicIncrementalGeneratorDemo).FullName!;
+	internal static Type CSharpDiagnosticAnalyzer => typeof(CSharpDiagnosticAnalyzerDemo);
+	internal static Type CSharpDiagnosticSuppressor => typeof(CSharpDiagnosticSuppressorDemo);
+	internal static Type CSharpSourceGenerator => typeof(CSharpSourceGeneratorDemo);
+	internal static Type CSharpIncrementalGenerator => typeof(CSharpIncrementalGeneratorDemo);
+	internal static Type VisualBasicDiagnosticAnalyzer => typeof(VisualBasicDiagnosticAnalyzerDemo);
+	internal static Type VisualBasicDiagnosticSuppressor => typeof(VisualBasicDiagnosticSuppressorDemo);
+	internal static Type VisualBasicSourceGenerator => typeof(VisualBasicSourceGeneratorDemo);
+	internal static Type VisualBasicIncrementalGenerator => typeof(VisualBasicIncrementalGeneratorDemo);
 }

--- a/source/tools/FlashOWare.CodeAnalysis.Inspection.Tool/Program.cs
+++ b/source/tools/FlashOWare.CodeAnalysis.Inspection.Tool/Program.cs
@@ -31,5 +31,13 @@ ImmutableArray<CompilerExtension> extensions = RoslynComponent.Inspect(stream);
 
 foreach (CompilerExtension extension in extensions)
 {
-	Console.WriteLine($"Extension '{extension.ClassName}' supports [{String.Join(", ", extension.Languages)}].");
+	string text = extension switch
+	{
+		AnalyzerInfo analyzer => $"Analyzer Extension '{analyzer.Class.Name}' supports [{String.Join(", ", analyzer.Attribute.Languages)}] with [{String.Join(", ", analyzer.SupportedDiagnostics.Select(diagnostic => diagnostic.Id))}].",
+		SuppressorInfo suppressor => $"Suppressor Extension '{suppressor.Class.Name}' supports [{String.Join(", ", suppressor.Attribute.Languages)}] with [{String.Join(", ", suppressor.SupportedSuppressions.Select(suppression => suppression.Id))}].",
+		GeneratorInfo generator => $"Generator Extension '{generator.Class.Name}' supports [{String.Join(", ", generator.Attribute.Languages)}].",
+		null => "Null Extension.",
+		_ => $"Unknown Extension Type: {extension.GetType()}",
+	};
+	Console.WriteLine(text);
 }


### PR DESCRIPTION
### Summary

Add inspections﻿ for _compiler extensions_ of type
- `DiagnosticAnalyzer`
- `DiagnosticSuppressor`

### Remarks

Partially implements #12

Live Stream: [2code ^ !2code [S2026E02] Inspector Roslyn and the Compiler Extensions](https://www.youtube.com/watch?v=x9wLxO4FadM)
